### PR TITLE
Using new Nemo export_config and --config options

### DIFF
--- a/nemo2riva/args.py
+++ b/nemo2riva/args.py
@@ -33,8 +33,17 @@ def get_args(argv):
         "--cache-support",
         type=lambda x: bool(strtobool(x)),
         default=None,
-        help="cache support for models that support it"
+        help="[ deprecated ] cache support for models that support it"
+    )
+    parser.add_argument(
+        "--config",
+        metavar="KEY=VALUE",
+        nargs='+',
+        help="Set a number of key-value pairs to model.export_config dictionary "
+        "(do not put spaces before or after the = sign). "
+        "Note that values are always treated as strings.",
     )
 
     args = parser.parse_args(argv)
+        
     return args

--- a/nemo2riva/args.py
+++ b/nemo2riva/args.py
@@ -36,7 +36,7 @@ def get_args(argv):
         help="[ deprecated ] cache support for models that support it"
     )
     parser.add_argument(
-        "--config",
+        "--export-config",
         metavar="KEY=VALUE",
         nargs='+',
         help="Set a number of key-value pairs to model.export_config dictionary "

--- a/nemo2riva/cookbook.py
+++ b/nemo2riva/cookbook.py
@@ -50,10 +50,13 @@ def export_model(model, cfg, args, artifacts, metadata):
     metadata.update(format_meta)
     runtime = format_meta["runtime"]
     metadata.update({"runtime": runtime})
-
-    if cfg.cache_support and hasattr(model, "encoder") and hasattr(model.encoder, "export_cache_support"):
-        model.encoder.export_cache_support = True
-        logging.info("Caching support is enabled.")
+    
+    if hasattr(model, "set_export_config"):
+        model.set_export_config(cfg.export_args)
+    else:
+        if cfg.export_args.get("cache_support", False) and hasattr(model, "encoder") and hasattr(model.encoder, "export_cache_support"):
+            model.encoder.export_cache_support = True
+            logging.info("Caching support is enabled.")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         export_filename = cfg.export_file
@@ -87,7 +90,7 @@ def export_model(model, cfg, args, artifacts, metadata):
                         input_example=input_example,
                         check_trace=args.runtime_check,
                         onnx_opset_version=args.onnx_opset,
-                        verbose=args.verbose,
+                        verbose=bool(args.verbose),
                     )
                     del model
                 if cfg.export_format == 'ONNX':

--- a/nemo2riva/schema.py
+++ b/nemo2riva/schema.py
@@ -4,7 +4,7 @@
 import os
 import sys
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import torch
 from eff.core import Archive
@@ -31,9 +31,8 @@ class ExportConfig:
     encryption: Optional[str] = None
     autocast: bool = False
     max_dim: int = None
-    cache_support: bool = False
-
-
+    export_args: Optional[Dict[str,str]] = None
+    
 @dataclass
 class ImportConfig:
     """Default config model for the model that exports to ONNX."""
@@ -91,8 +90,14 @@ def get_export_config(export_obj, args):
             "Format `{}` is invalid. Please pick one of the ({})".format(conf.export_format, supported_formats)
         )
 
-    if args.cache_support is not None:
-        conf.cache_support = args.cache_support
+    # TODO: read from schema
+    conf.export_args = {}
+    if args.config:
+        kv = dict(map(lambda s: s.split('='), args.config))
+        conf.export_args.update(kv)
+        
+    if args.cache_support:
+        conf.export_args.update({"cache_support": "True"})
 
     return conf
 

--- a/nemo2riva/schema.py
+++ b/nemo2riva/schema.py
@@ -90,12 +90,16 @@ def get_export_config(export_obj, args):
             "Format `{}` is invalid. Please pick one of the ({})".format(conf.export_format, supported_formats)
         )
 
-    # TODO: read from schema
+    # TODO: read from schema?
     conf.export_args = {}
-    if args.config:
-        kv = dict(map(lambda s: s.split('='), args.config))
-        conf.export_args.update(kv)
-        
+    if args.export_config:
+        for key_value in args.export_config:
+            lst = key_value.split("=")
+            if len(lst) != 2:
+                raise Exception("Use correct format for --export_config: k=v")
+            k, v = lst
+            conf.export_args[k] = v
+
     if args.cache_support:
         conf.export_args.update({"cache_support": "True"})
 


### PR DESCRIPTION
Changes to use new new Nemo export_config and --config options. For now, cache_support and decoder_type for Hybrid is supported. Need to add ragged batching / volume / etc to use the same mechanism.