### PR TITLE
Add IPA elongation symbol (ː) to list of supported non-alphanumeric IPA characters

### DIFF
--- a/nemo2riva/patches/tts/general.py
+++ b/nemo2riva/patches/tts/general.py
@@ -102,7 +102,7 @@ def generate_vocab_mapping_arpabet(labels):
 
 def generate_vocab_mapping_ipa(labels):
     # Only support English IPA dict
-    VALID_NON_ALNUM_IPA_TOKENS = ['ˈ', 'ˌ']
+    VALID_NON_ALNUM_IPA_TOKENS = ['ˈ', 'ˌ', 'ː']
     mapping = []
     for idx, token in enumerate(labels):
         if token in VALID_NON_ALNUM_IPA_TOKENS or (str.isalnum(token) and str.islower(token)):


### PR DESCRIPTION
TTS NeMo models trained using G2P dictionaries containing the IPA elongation symbol (`ː`) are not able to speak properly after being converted to Riva via `nemo2riva`. This is because the `ː` doesn't get prepended with a `@` symbol before being written to `mapping.txt`, which causes it to be skipped altogether at inference time. A hacky workaround is to manually fix the `mapping.txt` file after deploying the model, but that's not ideal.

Said elongation symbol is present in several dictionaries provided by NVIDIA themselves, including:
- the [de-DE G2P dictionary](https://github.com/NVIDIA/NeMo/blob/v1.20.0/scripts/tts_dataset_files/de/de_nv230119.dict) found in NeMo
- the [es-ES G2P dictionary](https://github.com/NVIDIA/NeMo/blob/v1.20.0/scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict) found in NeMo
- the [fr-FR G2P dictionary](https://github.com/NVIDIA/NeMo-text-processing/blob/0.2.0rc0/nemo_text_processing/g2p/data/fr_FR_g2p-v1.00-nv23.05.txt) found in NeMo-text-processing
- the [it-IT G2P dictionary](https://github.com/NVIDIA/NeMo-text-processing/blob/0.2.0rc0/nemo_text_processing/g2p/data/it_IT_g2p-v1.00-nv23.05.txt) found in NeMo-text-processing

This tiny-sized PR proposes to add that symbol to the list of supported non-alphanumeric IPA characters (see code).