### PR TITLE
Import Correct `Trainer` class from respective `nemo` version

### DIFF
--- a/nemo2riva/convert.py
+++ b/nemo2riva/convert.py
@@ -9,11 +9,10 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
-from nemo.core import ModelPT
+from nemo.core.classes.modelPT import ModelPT, Trainer
 from nemo.core.config.pytorch_lightning import TrainerConfig
 from nemo.utils import logging
 from omegaconf import OmegaConf
-from pytorch_lightning import Trainer
 
 from nemo2riva.artifacts import get_artifacts
 from nemo2riva.cookbook import export_model, save_archive


### PR DESCRIPTION
after `nemo_toolkit==2.0.0`, the `Trainer` class was changed to be imported from `lightning.pytorch` instead of `pytorch_lightning` which raised an error [here](https://github.com/NVIDIA/NeMo/blob/633cb602777bffefbe12066b0c915c87e7b469e9/nemo/core/classes/modelPT.py#L81) because the types do not match

This PR imports the same class that the type is checked against which makes it compatible with both `2.0.0` and `2.1.0` and later